### PR TITLE
updated mathjax cdn

### DIFF
--- a/scrap.html
+++ b/scrap.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" href="css/3dstyles.css">
 	
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-	<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 	<script type="text/x-mathjax-config">
 		MathJax.Hub.Config({ 
         	"HTML-CSS": { 


### PR DESCRIPTION
mathjax cdn no longer works, updated to cloudflare cdn for mathjax in scrap.html